### PR TITLE
Scroll to section fix

### DIFF
--- a/js/fullToolkit.js
+++ b/js/fullToolkit.js
@@ -147,17 +147,14 @@ const toggleAccordions = accordion => {
 // handle cases where users are navigating from toolpage category icons
 const zoomToSection = () => {
     let hash = window.location.hash
-    if(hash) {
-        
-        // make sure the passed hash follows the right pattern
-        if(hash.split('-'[1] === 'accordions')){
-            hash = hash.substr(1)
-            const el = document.getElementById(hash)
-            el.scrollTo({
-                top: 10,
-                behavior: 'smooth'
-            })
-        }
+    // make sure the passed hash follows the right pattern
+    if(hash && hash.split('-')[1] === 'accordions'){
+        hash = hash.substr(1)
+        const el = document.getElementById(hash)
+        el.scrollTo({
+            top: 10,
+            behavior: 'smooth'
+        })
     }
 }
 window.onload = () => zoomToSection()


### PR DESCRIPTION
Misplaced paren results in the expression never returning true. Also combine line with L150.

https://github.com/dvrpc/MIT/blob/36824daf74aa85adb2e72a0574b8b25e7d6e569a/js/fullToolkit.js#L153